### PR TITLE
Modernize layout using shadcn/ui cards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,8 +31,10 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-gray-100 flex items-center justify-center p-4">
-      <div className="container mx-auto grid md:grid-cols-2 gap-6 max-w-4xl">
-        <Card>
+      <div className="max-w-4xl mx-auto px-4 py-8 w-full">
+        <h1 className="text-2xl font-bold mb-4 text-center">Watch Flipping Calculator</h1>
+        <div className="grid gap-6 md:grid-cols-2">
+        <Card className="bg-muted/40 rounded-lg">
           <CardHeader>
             <CardTitle>Watch Details</CardTitle>
           </CardHeader>
@@ -64,11 +66,11 @@ export default function App() {
             </Button>
           </CardFooter>
         </Card>
-        <Card>
+        <Card className="bg-muted/40 rounded-lg">
           <CardHeader>
             <CardTitle>Results</CardTitle>
           </CardHeader>
-          <CardContent className="space-y-2 text-sm">
+          <CardContent className="space-y-3 text-sm md:text-base">
             <p>Total Costs: ${totalCosts.toFixed(2)}</p>
             <p>Break-Even Price: ${breakEvenPrice.toFixed(2)}</p>
             <p>Suggested Selling Price: ${suggestedPrice.toFixed(2)}</p>
@@ -76,6 +78,7 @@ export default function App() {
             <p className={profitColor}>ROI: {roi.toFixed(2)}%</p>
           </CardContent>
         </Card>
+        </div>
       </div>
     </div>
   )

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -1,7 +1,7 @@
 export default function Input({ className = '', ...props }) {
   return (
     <input
-      className={`flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+      className={`flex h-9 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- adjust input component spacing for mobile friendliness
- redesign `App.jsx` to use shadcn cards with a container and title
- make results text responsive and cards styled with a light background

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683ff0a82f5883308ebfafd7476288eb